### PR TITLE
Add region variable for SQL instance

### DIFF
--- a/rest-api-sql/deploy-rest-api.sh
+++ b/rest-api-sql/deploy-rest-api.sh
@@ -6,6 +6,8 @@
 PROJECT_ID=[YOUR GCP PROJECT ID FROM THE CLOUD CONSOLE]
 ROOT_PASSWORD=[COPY FROM create-database.sh]
 INSTANCE_NAME=[COPY FROM create-database.sh]
+REGION=[COPY FROM create-database.sh]
+INST_CON_NAME=$PROJECT_ID:$REGION:$INSTANCE_NAME
 DB_NAME=pet-theory
 
 gcloud builds submit --tag gcr.io/$PROJECT_ID/pet-theory-appointments \
@@ -16,6 +18,6 @@ gcloud beta run deploy pet-theory-appointments \
   --platform managed \
   --region us-central1 \
   --allow-unauthenticated \
-  --set-cloudsql-instances $INSTANCE_NAME \
-  --update-env-vars INST_CON_NAME=$PROJECT_ID:us-central1:$INSTANCE_NAME,SQL_USER=root,SQL_PASSWORD=$ROOT_PASSWORD,SQL_NAME=$DB_NAME \
+  --set-cloudsql-instances $INST_CON_NAME \
+  --update-env-vars INST_CON_NAME=$INST_CON_NAME,SQL_USER=root,SQL_PASSWORD=$ROOT_PASSWORD,SQL_NAME=$DB_NAME \
   --project $PROJECT_ID


### PR DESCRIPTION
I noticed --set-cloudsql-instances $INSTANCE_NAME will automatically resolve Cloud SQL's region to the same region as Cloud Run. This helps makes explicit the Cloud SQL region in case it's in a different region than Cloud Run